### PR TITLE
feat: add ImportExport component

### DIFF
--- a/src/popup/components/App.tsx
+++ b/src/popup/components/App.tsx
@@ -1,12 +1,13 @@
 import { useState, useCallback } from "react";
 import type { StorageType, StorageEntry, GetAllResponse } from "@/shared/types";
-import { createGetAllMessage, createSetValueMessage, createDeleteKeyMessage } from "@/shared/messages";
+import { createGetAllMessage, createSetValueMessage, createDeleteKeyMessage, createImportMessage } from "@/shared/messages";
 import { filterEntries } from "@/lib/filter";
 import styles from "./App.module.css";
 import { StorageToggle } from "./StorageToggle";
 import { SearchBar } from "./SearchBar";
 import { KeyList } from "./KeyList";
 import { ValueEditor } from "./ValueEditor";
+import { ImportExport } from "./ImportExport";
 
 type LoadState = "idle" | "loading" | "ready" | "error";
 
@@ -82,6 +83,19 @@ export function App() {
   const handleCopy = useCallback(async (value: string) => {
     await navigator.clipboard.writeText(value);
   }, []);
+
+  const handleImport = useCallback(
+    async (importEntries: Record<string, string>, clearFirst: boolean) => {
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (!tab?.id) return;
+      await chrome.tabs.sendMessage(
+        tab.id,
+        createImportMessage(storageType, importEntries, clearFirst),
+      );
+      loadEntries(storageType);
+    },
+    [storageType, loadEntries],
+  );
 
   const filteredEntries = filterEntries(entries, searchQuery);
 
@@ -160,6 +174,9 @@ export function App() {
           </>
         )}
       </div>
+      {loadState === "ready" && (
+        <ImportExport entries={entries} onImport={handleImport} />
+      )}
     </div>
   );
 }

--- a/src/popup/components/ImportExport.module.css
+++ b/src/popup/components/ImportExport.module.css
@@ -1,0 +1,89 @@
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-top: 1px solid #e0e0e0;
+  background: #fafafa;
+}
+
+.button {
+  padding: 3px 8px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.button:hover {
+  background: #f0f0f0;
+}
+
+.fileInput {
+  display: none;
+}
+
+.preview {
+  padding: 8px 12px;
+  background: #fff3e0;
+  border-top: 1px solid #ffe0b2;
+  font-size: 11px;
+}
+
+.previewTitle {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.previewKeys {
+  max-height: 80px;
+  overflow-y: auto;
+  margin: 4px 0;
+}
+
+.previewKey {
+  padding: 1px 0;
+  color: #555;
+}
+
+.overwrite {
+  color: #e65100;
+}
+
+.previewActions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.confirmButton {
+  padding: 3px 8px;
+  border: 1px solid #e65100;
+  border-radius: 3px;
+  background: #e65100;
+  color: white;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.confirmButton:hover {
+  background: #bf360c;
+}
+
+.cancelButton {
+  padding: 3px 8px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.error {
+  padding: 4px 10px;
+  background: #ffebee;
+  color: #d32f2f;
+  font-size: 11px;
+  border-top: 1px solid #ffcdd2;
+}

--- a/src/popup/components/ImportExport.tsx
+++ b/src/popup/components/ImportExport.tsx
@@ -1,0 +1,106 @@
+import { useState, useRef } from "react";
+import type { StorageEntry } from "@/shared/types";
+import { serializeExport, deserializeImport } from "@/lib/serialization";
+import styles from "./ImportExport.module.css";
+
+interface ImportExportProps {
+  entries: StorageEntry[];
+  onImport: (entries: Record<string, string>, clearFirst: boolean) => void;
+}
+
+export function ImportExport({ entries, onImport }: ImportExportProps) {
+  const [importPreview, setImportPreview] = useState<Record<string, string> | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const existingKeys = new Set(entries.map((e) => e.key));
+
+  const handleExport = () => {
+    const content = serializeExport(entries);
+    const blob = new Blob([content], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "storage-export.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const content = await file.text();
+    const result = deserializeImport(content);
+
+    if (!result.success) {
+      setImportError(result.error);
+      setImportPreview(null);
+    } else {
+      setImportPreview(result.entries);
+      setImportError(null);
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleConfirmImport = () => {
+    if (!importPreview) return;
+    onImport(importPreview, false);
+    setImportPreview(null);
+  };
+
+  const handleCancelImport = () => {
+    setImportPreview(null);
+    setImportError(null);
+  };
+
+  return (
+    <>
+      <div className={styles.bar}>
+        <button className={styles.button} onClick={handleExport}>
+          Export
+        </button>
+        <button className={styles.button} onClick={() => fileInputRef.current?.click()}>
+          Import
+        </button>
+        <input
+          ref={fileInputRef}
+          className={styles.fileInput}
+          type="file"
+          accept=".json"
+          onChange={handleFileSelect}
+        />
+      </div>
+      {importError && <div className={styles.error}>{importError}</div>}
+      {importPreview && (
+        <div className={styles.preview}>
+          <div className={styles.previewTitle}>
+            Import {Object.keys(importPreview).length} key(s):
+          </div>
+          <div className={styles.previewKeys}>
+            {Object.keys(importPreview).map((key) => (
+              <div
+                key={key}
+                className={`${styles.previewKey} ${existingKeys.has(key) ? styles.overwrite : ""}`}
+              >
+                {key}
+                {existingKeys.has(key) && " (overwrite)"}
+              </div>
+            ))}
+          </div>
+          <div className={styles.previewActions}>
+            <button className={styles.confirmButton} onClick={handleConfirmImport}>
+              Confirm Import
+            </button>
+            <button className={styles.cancelButton} onClick={handleCancelImport}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Closes #12

## Summary
- Created `ImportExport.tsx` with Export button (downloads JSON) and Import button (file picker with preview/confirmation flow)
- Created `ImportExport.module.css` with all required styles
- Wired `handleImport` callback into `App.tsx` using `createImportMessage`, rendered `<ImportExport>` when load state is ready
- Import preview highlights keys that will be overwritten in orange before confirming

## Test plan
- [ ] Export button downloads `storage-export.json` with all current entries
- [ ] Import button opens file picker accepting `.json` files
- [ ] Valid JSON shows preview with key count and overwrite indicators
- [ ] Confirm Import calls `onImport` and reloads entries
- [ ] Cancel dismisses the preview
- [ ] Invalid JSON shows error message
- [ ] `bun run lint && bun run test && bun run build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)