### PR TITLE
fix: deduplicate @codemirror packages to prevent instanceof crash

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
     alias: {
       "@": resolve(__dirname, "src"),
     },
+    dedupe: [
+      "@codemirror/state",
+      "@codemirror/view",
+      "@codemirror/language",
+    ],
   },
   test: {
     globals: false,


### PR DESCRIPTION
## Summary
Fixes #34

Vite was bundling multiple copies of `@codemirror/state`, which broke CodeMirror's internal `instanceof` checks causing a crash when opening the editor.

**Fix:** Add `resolve.dedupe` for `@codemirror/state`, `@codemirror/view`, and `@codemirror/language`.

**Bonus:** Bundle size dropped from 1,607KB to 614KB.

## Test plan
- [x] `bun run lint` passes
- [x] `bun run test` passes (31 tests)
- [x] `bun run build` succeeds
- [ ] Manual: load extension, click icon, select a key — editor renders without crash