### PR TITLE
feat: add change log diff highlighting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Storage Inspector",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "View and edit localStorage and sessionStorage with a proper JSON editor",
   "permissions": ["activeTab", "scripting", "sidePanel"],
   "action": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-storage-inspector",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -1,0 +1,112 @@
+export interface FieldChange {
+  path: string;
+  type: "added" | "removed" | "modified";
+}
+
+export function jsonDiff(
+  oldValue: string | null,
+  newValue: string | null,
+): FieldChange[] {
+  if (oldValue === null && newValue !== null)
+    return [{ path: "", type: "added" }];
+  if (oldValue !== null && newValue === null)
+    return [{ path: "", type: "removed" }];
+  if (oldValue === null || newValue === null) return [];
+  if (oldValue === newValue) return [];
+
+  const oldParsed = tryParseObject(oldValue);
+  const newParsed = tryParseObject(newValue);
+
+  if (oldParsed !== null && newParsed !== null) {
+    return compareValues(oldParsed, newParsed, "");
+  }
+
+  return [{ path: "", type: "modified" }];
+}
+
+function tryParseObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // not valid JSON
+  }
+  return null;
+}
+
+function compareValues(
+  oldVal: unknown,
+  newVal: unknown,
+  prefix: string,
+): FieldChange[] {
+  if (isPlainObject(oldVal) && isPlainObject(newVal)) {
+    return compareObjects(
+      oldVal as Record<string, unknown>,
+      newVal as Record<string, unknown>,
+      prefix,
+    );
+  }
+
+  if (Array.isArray(oldVal) && Array.isArray(newVal)) {
+    return compareArrays(oldVal, newVal, prefix);
+  }
+
+  if (JSON.stringify(oldVal) !== JSON.stringify(newVal)) {
+    return [{ path: prefix, type: "modified" }];
+  }
+
+  return [];
+}
+
+function compareObjects(
+  oldObj: Record<string, unknown>,
+  newObj: Record<string, unknown>,
+  prefix: string,
+): FieldChange[] {
+  const changes: FieldChange[] = [];
+  const allKeys = new Set([...Object.keys(oldObj), ...Object.keys(newObj)]);
+
+  for (const key of allKeys) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const hasOld = key in oldObj;
+    const hasNew = key in newObj;
+
+    if (!hasOld) {
+      changes.push({ path, type: "added" });
+    } else if (!hasNew) {
+      changes.push({ path, type: "removed" });
+    } else {
+      changes.push(...compareValues(oldObj[key], newObj[key], path));
+    }
+  }
+
+  return changes;
+}
+
+function compareArrays(
+  oldArr: unknown[],
+  newArr: unknown[],
+  prefix: string,
+): FieldChange[] {
+  const changes: FieldChange[] = [];
+  const maxLen = Math.max(oldArr.length, newArr.length);
+
+  for (let i = 0; i < maxLen; i++) {
+    const path = prefix ? `${prefix}.${i}` : `${i}`;
+    if (i >= oldArr.length) {
+      changes.push({ path, type: "added" });
+    } else if (i >= newArr.length) {
+      changes.push({ path, type: "removed" });
+    } else {
+      changes.push(...compareValues(oldArr[i], newArr[i], path));
+    }
+  }
+
+  return changes;
+}
+
+function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return typeof val === "object" && val !== null && !Array.isArray(val);
+}

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -110,3 +110,79 @@ function compareArrays(
 function isPlainObject(val: unknown): val is Record<string, unknown> {
   return typeof val === "object" && val !== null && !Array.isArray(val);
 }
+
+export interface DiffLine {
+  text: string;
+  type: "added" | "removed" | "unchanged";
+}
+
+const MAX_SUMMARY_ITEMS = 3;
+
+const SUMMARY_PREFIX: Record<FieldChange["type"], string> = {
+  added: "+",
+  removed: "-",
+  modified: "~",
+};
+
+export function formatChangeSummary(changes: FieldChange[]): string {
+  if (changes.length === 0) return "";
+
+  if (changes.length === 1 && changes[0].path === "") {
+    switch (changes[0].type) {
+      case "added":
+        return "(new)";
+      case "removed":
+        return "(deleted)";
+      case "modified":
+        return "value changed";
+    }
+  }
+
+  const shown = changes.slice(0, MAX_SUMMARY_ITEMS);
+  const parts = shown.map((c) => `${SUMMARY_PREFIX[c.type]} ${c.path}`);
+  const remaining = changes.length - MAX_SUMMARY_ITEMS;
+  if (remaining > 0) {
+    parts.push(`+${remaining} more`);
+  }
+  return parts.join(", ");
+}
+
+export function diffLines(oldText: string, newText: string): DiffLine[] {
+  const oldLines = oldText.split("\n");
+  const newLines = newText.split("\n");
+
+  const m = oldLines.length;
+  const n = newLines.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array<number>(n + 1).fill(0),
+  );
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  const result: DiffLine[] = [];
+  let i = m;
+  let j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      result.unshift({ text: oldLines[i - 1], type: "unchanged" });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      result.unshift({ text: newLines[j - 1], type: "added" });
+      j--;
+    } else {
+      result.unshift({ text: oldLines[i - 1], type: "removed" });
+      i--;
+    }
+  }
+
+  return result;
+}

--- a/src/sidepanel/components/ChangeLog.module.css
+++ b/src/sidepanel/components/ChangeLog.module.css
@@ -189,6 +189,3 @@
   background: #e3f2fd;
 }
 
-.diffModified {
-  background: #fff8e1;
-}

--- a/src/sidepanel/components/ChangeLog.module.css
+++ b/src/sidepanel/components/ChangeLog.module.css
@@ -151,3 +151,44 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+.diffToolbar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.diffModeButton,
+.diffModeActive {
+  padding: 1px 6px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 10px;
+}
+
+.diffModeActive {
+  background: #e0e0e0;
+  font-weight: 600;
+}
+
+.diffBlock {
+  font-family: monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+}
+
+.diffRemoved {
+  background: #fce4ec;
+}
+
+.diffAdded {
+  background: #e3f2fd;
+}
+
+.diffModified {
+  background: #fff8e1;
+}

--- a/src/sidepanel/components/ChangeLog.module.css
+++ b/src/sidepanel/components/ChangeLog.module.css
@@ -141,3 +141,13 @@
   text-align: center;
   font-style: italic;
 }
+
+.changeSummary {
+  font-size: 11px;
+  color: #888;
+  margin-top: 2px;
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/sidepanel/components/ChangeLog.tsx
+++ b/src/sidepanel/components/ChangeLog.tsx
@@ -52,7 +52,7 @@ function InlineDiff({
               .filter((l) => l.type !== "added")
               .map((line, i) => (
                 <div
-                  key={i}
+                  key={`old-${i}`}
                   className={
                     line.type === "removed" ? styles.diffRemoved : undefined
                   }
@@ -69,7 +69,7 @@ function InlineDiff({
           .filter((l) => l.type !== "removed")
           .map((line, i) => (
             <div
-              key={i}
+              key={`new-${i}`}
               className={
                 line.type === "added" ? styles.diffAdded : undefined
               }

--- a/src/sidepanel/components/ChangeLog.tsx
+++ b/src/sidepanel/components/ChangeLog.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { StorageChangeEvent } from "@/shared/types";
-import { jsonDiff, formatChangeSummary } from "@/lib/diff";
+import { jsonDiff, formatChangeSummary, diffLines } from "@/lib/diff";
 import styles from "./ChangeLog.module.css";
 
 const MAX_ENTRIES = 100;
@@ -31,8 +31,92 @@ function formatValue(value: string | null): string {
   }
 }
 
+function InlineDiff({
+  oldValue,
+  newValue,
+}: {
+  oldValue: string | null;
+  newValue: string | null;
+}) {
+  const oldText = formatValue(oldValue);
+  const newText = formatValue(newValue);
+  const lines = diffLines(oldText, newText);
+
+  return (
+    <>
+      {oldValue !== null && (
+        <>
+          <div className={styles.detailLabel}>Old</div>
+          <pre className={styles.diffBlock}>
+            {lines
+              .filter((l) => l.type !== "added")
+              .map((line, i) => (
+                <div
+                  key={i}
+                  className={
+                    line.type === "removed" ? styles.diffRemoved : undefined
+                  }
+                >
+                  {line.text}
+                </div>
+              ))}
+          </pre>
+        </>
+      )}
+      <div className={styles.detailLabel}>New</div>
+      <pre className={styles.diffBlock}>
+        {lines
+          .filter((l) => l.type !== "removed")
+          .map((line, i) => (
+            <div
+              key={i}
+              className={
+                line.type === "added" ? styles.diffAdded : undefined
+              }
+            >
+              {line.text}
+            </div>
+          ))}
+      </pre>
+    </>
+  );
+}
+
+function UnifiedDiff({
+  oldValue,
+  newValue,
+}: {
+  oldValue: string | null;
+  newValue: string | null;
+}) {
+  const oldText = formatValue(oldValue);
+  const newText = formatValue(newValue);
+  const lines = diffLines(oldText, newText);
+
+  return (
+    <pre className={styles.diffBlock}>
+      {lines.map((line, i) => {
+        const prefix =
+          line.type === "added" ? "+" : line.type === "removed" ? "-" : " ";
+        const className =
+          line.type === "added"
+            ? styles.diffAdded
+            : line.type === "removed"
+              ? styles.diffRemoved
+              : undefined;
+        return (
+          <div key={i} className={className}>
+            {prefix} {line.text}
+          </div>
+        );
+      })}
+    </pre>
+  );
+}
+
 function ChangeEntry({ change }: { change: StorageChangeEvent }) {
   const [expanded, setExpanded] = useState(false);
+  const [diffMode, setDiffMode] = useState<"inline" | "unified">("inline");
 
   const fieldChanges =
     change.operation !== "clear"
@@ -73,14 +157,44 @@ function ChangeEntry({ change }: { change: StorageChangeEvent }) {
       )}
       {expanded && change.operation !== "clear" && (
         <div className={styles.entryDetail}>
-          {change.oldValue !== null && (
-            <>
-              <div className={styles.detailLabel}>Old</div>
-              <div>{formatValue(change.oldValue)}</div>
-            </>
+          <div className={styles.diffToolbar}>
+            <button
+              className={
+                diffMode === "inline"
+                  ? styles.diffModeActive
+                  : styles.diffModeButton
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                setDiffMode("inline");
+              }}
+              data-testid="diff-mode-inline"
+            >
+              Inline
+            </button>
+            <button
+              className={
+                diffMode === "unified"
+                  ? styles.diffModeActive
+                  : styles.diffModeButton
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+                setDiffMode("unified");
+              }}
+              data-testid="diff-mode-unified"
+            >
+              Unified
+            </button>
+          </div>
+          {diffMode === "inline" ? (
+            <InlineDiff oldValue={change.oldValue} newValue={change.newValue} />
+          ) : (
+            <UnifiedDiff
+              oldValue={change.oldValue}
+              newValue={change.newValue}
+            />
           )}
-          <div className={styles.detailLabel}>New</div>
-          <div>{formatValue(change.newValue)}</div>
         </div>
       )}
     </div>

--- a/src/sidepanel/components/ChangeLog.tsx
+++ b/src/sidepanel/components/ChangeLog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { StorageChangeEvent } from "@/shared/types";
+import { jsonDiff, formatChangeSummary } from "@/lib/diff";
 import styles from "./ChangeLog.module.css";
 
 const MAX_ENTRIES = 100;
@@ -33,12 +34,24 @@ function formatValue(value: string | null): string {
 function ChangeEntry({ change }: { change: StorageChangeEvent }) {
   const [expanded, setExpanded] = useState(false);
 
-  const sourceClass = change.source === "extension"
-    ? `${styles.entrySource} ${styles.entrySourceExtension}`
-    : styles.entrySource;
+  const fieldChanges =
+    change.operation !== "clear"
+      ? jsonDiff(change.oldValue, change.newValue)
+      : [];
+  const summary =
+    change.operation === "clear" ? "" : formatChangeSummary(fieldChanges);
+
+  const sourceClass =
+    change.source === "extension"
+      ? `${styles.entrySource} ${styles.entrySourceExtension}`
+      : styles.entrySource;
 
   return (
-    <div className={styles.entry} onClick={() => setExpanded(!expanded)} data-testid="change-entry">
+    <div
+      className={styles.entry}
+      onClick={() => setExpanded(!expanded)}
+      data-testid="change-entry"
+    >
       <div className={styles.entryHeader}>
         <span className={styles.entryKey} title={change.key ?? undefined}>
           {change.key ?? "(all)"}
@@ -53,6 +66,11 @@ function ChangeEntry({ change }: { change: StorageChangeEvent }) {
           {formatTimestamp(change.timestamp)}
         </span>
       </div>
+      {summary && (
+        <div className={styles.changeSummary} data-testid="change-summary">
+          {summary}
+        </div>
+      )}
       {expanded && change.operation !== "clear" && (
         <div className={styles.entryDetail}>
           {change.oldValue !== null && (

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -411,3 +411,123 @@ test.describe("Change Monitoring", () => {
   });
 
 });
+
+test.describe("Change Log Diff", () => {
+  test("shows field-level summary for JSON changes in collapsed view", async ({
+    page,
+    openSidePanel,
+  }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    // Set initial JSON value
+    await page.evaluate(() => {
+      localStorage.setItem("diff-test", JSON.stringify({ name: "Alice", age: 30 }));
+    });
+    await expect(sidePanelPage.getByTestId("change-entry").first()).toBeVisible({ timeout: 3000 });
+
+    // Update with field change
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "diff-test",
+        JSON.stringify({ name: "Alice", age: 31, role: "admin" }),
+      );
+    });
+    await expect(sidePanelPage.getByTestId("change-count")).toContainText("2 changes", { timeout: 3000 });
+
+    // Most recent entry should have a change summary
+    const summary = sidePanelPage.getByTestId("change-summary").first();
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText("~");
+
+    await sidePanelPage.close();
+  });
+
+  test("shows '(new)' summary for new keys", async ({ page, openSidePanel }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    await page.evaluate(() => {
+      localStorage.setItem("brand-new-key", "some-value");
+    });
+
+    const summary = sidePanelPage.getByTestId("change-summary").first();
+    await expect(summary).toBeVisible({ timeout: 3000 });
+    await expect(summary).toContainText("(new)");
+
+    await sidePanelPage.close();
+  });
+
+  test("shows 'value changed' summary for plain string changes", async ({
+    page,
+    openSidePanel,
+  }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    await page.evaluate(() => {
+      localStorage.setItem("str-test", "first");
+    });
+    await expect(sidePanelPage.getByTestId("change-entry").first()).toBeVisible({ timeout: 3000 });
+
+    await page.evaluate(() => {
+      localStorage.setItem("str-test", "second");
+    });
+    await expect(sidePanelPage.getByTestId("change-count")).toContainText("2 changes", { timeout: 3000 });
+
+    const summary = sidePanelPage.getByTestId("change-summary").first();
+    await expect(summary).toContainText("value changed");
+
+    await sidePanelPage.close();
+  });
+
+  test("expanded inline diff highlights changed lines", async ({
+    page,
+    openSidePanel,
+  }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    await page.evaluate(() => {
+      localStorage.setItem("inline-test", JSON.stringify({ name: "Alice", age: 30 }));
+    });
+    await expect(sidePanelPage.getByTestId("change-entry").first()).toBeVisible({ timeout: 3000 });
+
+    await page.evaluate(() => {
+      localStorage.setItem("inline-test", JSON.stringify({ name: "Alice", age: 31 }));
+    });
+    await expect(sidePanelPage.getByTestId("change-count")).toContainText("2 changes", { timeout: 3000 });
+
+    // Expand the most recent entry
+    await sidePanelPage.getByTestId("change-entry").first().click();
+
+    // Should show inline diff by default with diff mode buttons
+    await expect(sidePanelPage.getByTestId("diff-mode-inline")).toBeVisible();
+    await expect(sidePanelPage.getByTestId("diff-mode-unified")).toBeVisible();
+
+    await sidePanelPage.close();
+  });
+
+  test("toggle to unified diff shows +/- prefixed lines", async ({
+    page,
+    openSidePanel,
+  }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    await page.evaluate(() => {
+      localStorage.setItem("unified-test", "old-value");
+    });
+    await expect(sidePanelPage.getByTestId("change-entry").first()).toBeVisible({ timeout: 3000 });
+
+    await page.evaluate(() => {
+      localStorage.setItem("unified-test", "new-value");
+    });
+    await expect(sidePanelPage.getByTestId("change-count")).toContainText("2 changes", { timeout: 3000 });
+
+    // Expand and switch to unified
+    await sidePanelPage.getByTestId("change-entry").first().click();
+    await sidePanelPage.getByTestId("diff-mode-unified").click();
+
+    // Unified view should show - and + prefixed lines
+    await expect(sidePanelPage.locator("text=- old-value")).toBeVisible();
+    await expect(sidePanelPage.locator("text=+ new-value")).toBeVisible();
+
+    await sidePanelPage.close();
+  });
+});

--- a/tests/unit/diff.test.ts
+++ b/tests/unit/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { jsonDiff } from "@/lib/diff";
-import type { FieldChange } from "@/lib/diff";
+import { jsonDiff, formatChangeSummary, diffLines } from "@/lib/diff";
+import type { FieldChange, DiffLine } from "@/lib/diff";
 
 describe("jsonDiff", () => {
   it("returns empty array for identical JSON objects", () => {
@@ -95,5 +95,90 @@ describe("jsonDiff", () => {
 
   it("returns single modified entry for root-level arrays", () => {
     expect(jsonDiff("[1,2]", "[1,3]")).toEqual([{ path: "", type: "modified" }]);
+  });
+});
+
+describe("formatChangeSummary", () => {
+  it("returns empty string for no changes", () => {
+    expect(formatChangeSummary([])).toBe("");
+  });
+
+  it("returns '(new)' for root-level add", () => {
+    expect(formatChangeSummary([{ path: "", type: "added" }])).toBe("(new)");
+  });
+
+  it("returns '(deleted)' for root-level remove", () => {
+    expect(formatChangeSummary([{ path: "", type: "removed" }])).toBe("(deleted)");
+  });
+
+  it("returns 'value changed' for root-level modify", () => {
+    expect(formatChangeSummary([{ path: "", type: "modified" }])).toBe("value changed");
+  });
+
+  it("formats field changes with prefixes", () => {
+    const changes: FieldChange[] = [
+      { path: "age", type: "modified" },
+      { path: "roles", type: "added" },
+      { path: "legacy", type: "removed" },
+    ];
+    expect(formatChangeSummary(changes)).toBe("~ age, + roles, - legacy");
+  });
+
+  it("truncates to 3 changes with +N more", () => {
+    const changes: FieldChange[] = [
+      { path: "a", type: "modified" },
+      { path: "b", type: "added" },
+      { path: "c", type: "removed" },
+      { path: "d", type: "modified" },
+      { path: "e", type: "added" },
+    ];
+    expect(formatChangeSummary(changes)).toBe("~ a, + b, - c, +2 more");
+  });
+});
+
+describe("diffLines", () => {
+  it("returns all unchanged for identical text", () => {
+    const result = diffLines("line1\nline2", "line1\nline2");
+    expect(result).toEqual([
+      { text: "line1", type: "unchanged" },
+      { text: "line2", type: "unchanged" },
+    ]);
+  });
+
+  it("detects added lines", () => {
+    const result = diffLines("a", "a\nb");
+    expect(result).toEqual([
+      { text: "a", type: "unchanged" },
+      { text: "b", type: "added" },
+    ]);
+  });
+
+  it("detects removed lines", () => {
+    const result = diffLines("a\nb", "a");
+    expect(result).toEqual([
+      { text: "a", type: "unchanged" },
+      { text: "b", type: "removed" },
+    ]);
+  });
+
+  it("detects modified lines as remove + add", () => {
+    const result = diffLines("old-line", "new-line");
+    expect(result).toEqual([
+      { text: "old-line", type: "removed" },
+      { text: "new-line", type: "added" },
+    ]);
+  });
+
+  it("handles multi-line JSON diff", () => {
+    const oldText = '{\n  "name": "Alice",\n  "age": 30\n}';
+    const newText = '{\n  "name": "Alice",\n  "age": 31\n}';
+    const result = diffLines(oldText, newText);
+
+    const removed = result.filter((l: DiffLine) => l.type === "removed");
+    const added = result.filter((l: DiffLine) => l.type === "added");
+    expect(removed).toHaveLength(1);
+    expect(removed[0].text).toContain("30");
+    expect(added).toHaveLength(1);
+    expect(added[0].text).toContain("31");
   });
 });

--- a/tests/unit/diff.test.ts
+++ b/tests/unit/diff.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { jsonDiff } from "@/lib/diff";
+import type { FieldChange } from "@/lib/diff";
+
+describe("jsonDiff", () => {
+  it("returns empty array for identical JSON objects", () => {
+    const json = JSON.stringify({ name: "Alice", age: 30 });
+    expect(jsonDiff(json, json)).toEqual([]);
+  });
+
+  it("returns empty array for identical strings", () => {
+    expect(jsonDiff("hello", "hello")).toEqual([]);
+  });
+
+  it("returns added when oldValue is null", () => {
+    expect(jsonDiff(null, "value")).toEqual([{ path: "", type: "added" }]);
+  });
+
+  it("returns removed when newValue is null", () => {
+    expect(jsonDiff("value", null)).toEqual([{ path: "", type: "removed" }]);
+  });
+
+  it("returns empty array when both are null", () => {
+    expect(jsonDiff(null, null)).toEqual([]);
+  });
+
+  it("detects top-level field added", () => {
+    const oldVal = JSON.stringify({ name: "Alice" });
+    const newVal = JSON.stringify({ name: "Alice", age: 30 });
+    expect(jsonDiff(oldVal, newVal)).toEqual([{ path: "age", type: "added" }]);
+  });
+
+  it("detects top-level field removed", () => {
+    const oldVal = JSON.stringify({ name: "Alice", age: 30 });
+    const newVal = JSON.stringify({ name: "Alice" });
+    expect(jsonDiff(oldVal, newVal)).toEqual([{ path: "age", type: "removed" }]);
+  });
+
+  it("detects top-level field modified", () => {
+    const oldVal = JSON.stringify({ name: "Alice", age: 30 });
+    const newVal = JSON.stringify({ name: "Alice", age: 31 });
+    expect(jsonDiff(oldVal, newVal)).toEqual([{ path: "age", type: "modified" }]);
+  });
+
+  it("detects nested field changes with dot-notation paths", () => {
+    const oldVal = JSON.stringify({ user: { settings: { theme: "light" } } });
+    const newVal = JSON.stringify({ user: { settings: { theme: "dark" } } });
+    expect(jsonDiff(oldVal, newVal)).toEqual([
+      { path: "user.settings.theme", type: "modified" },
+    ]);
+  });
+
+  it("detects multiple nested changes", () => {
+    const oldVal = JSON.stringify({ user: { name: "Alice", age: 30 } });
+    const newVal = JSON.stringify({ user: { name: "Bob", age: 30, role: "admin" } });
+    const changes = jsonDiff(oldVal, newVal);
+    expect(changes).toContainEqual({ path: "user.name", type: "modified" });
+    expect(changes).toContainEqual({ path: "user.role", type: "added" });
+    expect(changes).toHaveLength(2);
+  });
+
+  it("detects array element changes by index", () => {
+    const oldVal = JSON.stringify({ items: ["a", "b", "c"] });
+    const newVal = JSON.stringify({ items: ["a", "x", "c"] });
+    expect(jsonDiff(oldVal, newVal)).toEqual([
+      { path: "items.1", type: "modified" },
+    ]);
+  });
+
+  it("detects array element added", () => {
+    const oldVal = JSON.stringify({ items: ["a"] });
+    const newVal = JSON.stringify({ items: ["a", "b"] });
+    expect(jsonDiff(oldVal, newVal)).toEqual([
+      { path: "items.1", type: "added" },
+    ]);
+  });
+
+  it("detects array element removed", () => {
+    const oldVal = JSON.stringify({ items: ["a", "b"] });
+    const newVal = JSON.stringify({ items: ["a"] });
+    expect(jsonDiff(oldVal, newVal)).toEqual([
+      { path: "items.1", type: "removed" },
+    ]);
+  });
+
+  it("returns single modified entry for non-JSON strings", () => {
+    expect(jsonDiff("hello", "world")).toEqual([{ path: "", type: "modified" }]);
+  });
+
+  it("returns single modified entry when types differ (string vs JSON)", () => {
+    expect(jsonDiff("plain", JSON.stringify({ a: 1 }))).toEqual([
+      { path: "", type: "modified" },
+    ]);
+  });
+
+  it("returns single modified entry for root-level arrays", () => {
+    expect(jsonDiff("[1,2]", "[1,3]")).toEqual([{ path: "", type: "modified" }]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add field-level JSON diff to collapsed change log entries (`~ age, + roles, - legacy`)
- Add inline/unified diff toggle in expanded view with color highlighting
- Pure diff functions in `src/lib/diff.ts` with full unit test coverage

Closes #46

## Test plan
- [x] Unit tests for `jsonDiff`, `formatChangeSummary`, `diffLines` (27 tests)
- [x] E2E tests for collapsed summary, inline diff, unified diff toggle (5 tests)
- [x] All 23 E2E tests pass, 67 unit tests pass
- [x] Lint, type-check, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)