### PR TITLE
fix: interceptor blocked by ad blockers and CSP

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Storage Inspector",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "View and edit localStorage and sessionStorage with a proper JSON editor",
   "permissions": ["activeTab", "scripting", "sidePanel"],
   "action": {

--- a/manifest.json
+++ b/manifest.json
@@ -26,14 +26,15 @@
       "matches": ["<all_urls>"],
       "js": ["src/content/monitor.ts"],
       "run_at": "document_idle"
-    }
-  ],
-  "web_accessible_resources": [
+    },
     {
-      "resources": ["storage-interceptor.js"],
-      "matches": ["<all_urls>"]
+      "matches": ["<all_urls>"],
+      "js": ["public/storage-interceptor.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
     }
   ],
+  "web_accessible_resources": [],
   "background": {
     "service_worker": "src/background/service-worker.ts"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-storage-inspector",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/public/storage-interceptor.js
+++ b/public/storage-interceptor.js
@@ -93,11 +93,4 @@
     }
   };
 
-  // Listen for extension flag setting from monitor (via postMessage from ISOLATED world)
-  window.addEventListener("message", function (event) {
-    if (event.data && event.data._lsi === "monitor" && event.data.type === "SET_EXTENSION_FLAG") {
-      window[EXTENSION_FLAG] = true;
-      window.postMessage({ _lsi: "interceptor", type: "EXTENSION_FLAG_SET" }, "*");
-    }
-  });
 })();

--- a/public/storage-interceptor.js
+++ b/public/storage-interceptor.js
@@ -1,5 +1,5 @@
 // MAIN world script — monkey-patches Storage.prototype to capture mutations.
-// Injected via <script> tag by the monitor content script.
+// Declared in manifest.json (world: "MAIN") to avoid ad blocker / CSP blocking.
 // Communicates with the ISOLATED world monitor via window.postMessage.
 
 (function () {

--- a/src/content/monitor.ts
+++ b/src/content/monitor.ts
@@ -35,7 +35,6 @@ function queueChange(event: StorageChangeEvent): void {
 // Listen for change events from the MAIN world interceptor
 window.addEventListener("message", (event) => {
   if (event.data?._lsi !== "interceptor") return;
-  if (event.data.type === "EXTENSION_FLAG_SET") return;
 
   const change: StorageChangeEvent = {
     storageType: event.data.storageType,

--- a/src/content/monitor.ts
+++ b/src/content/monitor.ts
@@ -1,12 +1,12 @@
-// ISOLATED world content script — bridges the MAIN world interceptor and the sidepanel.
-// Registered in manifest.json content_scripts.
-// Injects/removes the interceptor, relays change events via chrome.runtime.sendMessage.
+// ISOLATED world content script — relays change events from the MAIN world
+// interceptor to the sidepanel via chrome.runtime.sendMessage.
+// The interceptor is now declared in manifest.json (world: "MAIN"),
+// so no dynamic injection is needed.
 
-import type { StorageChangeEvent, StorageChangePortMessage, MonitorMessage } from "@/shared/types";
+import type { StorageChangeEvent, StorageChangePortMessage } from "@/shared/types";
 
 const BATCH_INTERVAL_MS = 50;
 
-let scriptTag: HTMLScriptElement | null = null;
 let batchBuffer: StorageChangeEvent[] = [];
 let batchTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -32,25 +32,6 @@ function queueChange(event: StorageChangeEvent): void {
   }
 }
 
-function injectInterceptor(): void {
-  if (scriptTag) return;
-  scriptTag = document.createElement("script");
-  scriptTag.src = chrome.runtime.getURL("storage-interceptor.js");
-  (document.head || document.documentElement).appendChild(scriptTag);
-}
-
-function removeInterceptor(): void {
-  if (scriptTag) {
-    scriptTag.remove();
-    scriptTag = null;
-  }
-  if (batchTimer) {
-    clearTimeout(batchTimer);
-    batchTimer = null;
-  }
-  flushBatch();
-}
-
 // Listen for change events from the MAIN world interceptor
 window.addEventListener("message", (event) => {
   if (event.data?._lsi !== "interceptor") return;
@@ -68,32 +49,3 @@ window.addEventListener("message", (event) => {
 
   queueChange(change);
 });
-
-// Listen for messages from the sidepanel
-chrome.runtime.onMessage.addListener(
-  (message: MonitorMessage, _sender, sendResponse) => {
-    switch (message.type) {
-      case "START_RECORDING":
-        injectInterceptor();
-        break;
-      case "STOP_RECORDING":
-        removeInterceptor();
-        break;
-      case "SET_EXTENSION_FLAG": {
-        window.postMessage({ _lsi: "monitor", type: "SET_EXTENSION_FLAG" }, "*");
-        const handler = (event: MessageEvent) => {
-          if (event.data?._lsi === "interceptor" && event.data?.type === "EXTENSION_FLAG_SET") {
-            window.removeEventListener("message", handler);
-            sendResponse({ type: "SET_EXTENSION_FLAG_RESPONSE", success: true });
-          }
-        };
-        window.addEventListener("message", handler);
-        setTimeout(() => {
-          window.removeEventListener("message", handler);
-          sendResponse({ type: "SET_EXTENSION_FLAG_RESPONSE", success: false });
-        }, 500);
-        return true;
-      }
-    }
-  },
-);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -70,27 +70,7 @@ export interface StorageChangeEvent {
   source: ChangeSource;
 }
 
-export interface StartRecordingMessage {
-  type: "START_RECORDING";
-}
-
-export interface StopRecordingMessage {
-  type: "STOP_RECORDING";
-}
-
-export interface SetExtensionFlagMessage {
-  type: "SET_EXTENSION_FLAG";
-}
-
-export interface SetExtensionFlagResponse {
-  type: "SET_EXTENSION_FLAG_RESPONSE";
-  success: boolean;
-}
-
 export interface StorageChangePortMessage {
   type: "STORAGE_CHANGE";
   changes: StorageChangeEvent[];
 }
-
-export type MonitorMessage = StartRecordingMessage | StopRecordingMessage | SetExtensionFlagMessage;
-export type MonitorResponse = SetExtensionFlagResponse;

--- a/src/sidepanel/components/App.tsx
+++ b/src/sidepanel/components/App.tsx
@@ -31,18 +31,25 @@ function readStorage(storageType: string): Array<{ key: string; value: string }>
 
 function writeStorage(storageType: string, key: string, value: string): void {
   const storage = storageType === "localStorage" ? localStorage : sessionStorage;
+  (window as unknown as Record<symbol, unknown>)[Symbol.for("lsi-extension-flag")] = true;
   storage.setItem(key, value);
 }
 
 function removeFromStorage(storageType: string, key: string): void {
   const storage = storageType === "localStorage" ? localStorage : sessionStorage;
+  (window as unknown as Record<symbol, unknown>)[Symbol.for("lsi-extension-flag")] = true;
   storage.removeItem(key);
 }
 
 function importToStorage(storageType: string, entries: Record<string, string>, clearFirst: boolean): void {
   const storage = storageType === "localStorage" ? localStorage : sessionStorage;
-  if (clearFirst) storage.clear();
+  const FLAG = Symbol.for("lsi-extension-flag");
+  if (clearFirst) {
+    (window as unknown as Record<symbol, unknown>)[FLAG] = true;
+    storage.clear();
+  }
   for (const [key, value] of Object.entries(entries)) {
+    (window as unknown as Record<symbol, unknown>)[FLAG] = true;
     storage.setItem(key, value);
   }
 }
@@ -75,17 +82,6 @@ export function App() {
     });
   }, []);
 
-  // Start/stop recording by messaging the content script
-  const sendRecordingMessage = useCallback(async (start: boolean) => {
-    const tabId = await getActiveTabId();
-    if (!tabId) return;
-    try {
-      await chrome.tabs.sendMessage(tabId, { type: start ? "START_RECORDING" : "STOP_RECORDING" });
-    } catch {
-      // Content script may not be ready yet
-    }
-  }, []);
-
   // Listen for change events from the content script via runtime messages
   useEffect(() => {
     const handleMessage = (message: StorageChangePortMessage) => {
@@ -98,17 +94,11 @@ export function App() {
     return () => chrome.runtime.onMessage.removeListener(handleMessage);
   }, [addChanges]);
 
-  // Start recording on initial load
-  useEffect(() => {
-    sendRecordingMessage(true);
-  }, [sendRecordingMessage]);
-
   const handleToggleRecording = useCallback(() => {
     const newRecording = !recordingRef.current;
     recordingRef.current = newRecording;
     setRecording(newRecording);
-    sendRecordingMessage(newRecording);
-  }, [sendRecordingMessage]);
+  }, []);
 
   const handleClearChanges = useCallback(() => {
     setChanges([]);
@@ -155,6 +145,7 @@ export function App() {
       if (!tabId) return;
       await chrome.scripting.executeScript({
         target: { tabId },
+        world: "MAIN",
         func: writeStorage,
         args: [storageType, key, value],
       });
@@ -171,6 +162,7 @@ export function App() {
       if (!tabId) return;
       await chrome.scripting.executeScript({
         target: { tabId },
+        world: "MAIN",
         func: removeFromStorage,
         args: [storageType, key],
       });
@@ -190,6 +182,7 @@ export function App() {
       if (!tabId) return;
       await chrome.scripting.executeScript({
         target: { tabId },
+        world: "MAIN",
         func: importToStorage,
         args: [storageType, importEntries, clearFirst],
       });

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -410,6 +410,54 @@ test.describe("Change Monitoring", () => {
     await sidePanelPage.close();
   });
 
+  test("captures extension-initiated save with source extension", async ({
+    page,
+    openSidePanel,
+  }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    // Click a key to select it
+    await sidePanelPage.locator("text=basic-test").click();
+
+    // Edit the value in the CodeMirror editor
+    const editor = sidePanelPage.locator(".cm-content");
+    await editor.click();
+    await sidePanelPage.keyboard.press("Meta+a");
+    await sidePanelPage.keyboard.type("updated-value");
+
+    // Save
+    await sidePanelPage.locator("button", { hasText: "Save" }).click();
+
+    // A change entry should appear with source "extension"
+    const entry = sidePanelPage.getByTestId("change-entry").first();
+    await expect(entry).toBeVisible({ timeout: 3000 });
+    await expect(entry.getByTestId("change-source")).toContainText("extension");
+
+    await sidePanelPage.close();
+  });
+
+  test("captures extension-initiated delete with source extension", async ({
+    page,
+    openSidePanel,
+  }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    // Click a key to select it
+    await sidePanelPage.locator("text=basic-test").click();
+
+    // Delete it (first click shows "Confirm?", second click deletes)
+    await sidePanelPage.locator("button", { hasText: "Delete" }).click();
+    await sidePanelPage.locator("button", { hasText: "Confirm?" }).click();
+
+    // A change entry should appear with source "extension"
+    const entry = sidePanelPage.getByTestId("change-entry").first();
+    await expect(entry).toBeVisible({ timeout: 3000 });
+    await expect(entry.getByTestId("change-operation")).toContainText("removeItem");
+    await expect(entry.getByTestId("change-source")).toContainText("extension");
+
+    await sidePanelPage.close();
+  });
+
 });
 
 test.describe("Change Log Diff", () => {

--- a/tests/unit/types-monitoring.test.ts
+++ b/tests/unit/types-monitoring.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import type {
   StorageChangeEvent,
   StorageChangePortMessage,
-  MonitorMessage,
   StorageOperation,
   ChangeSource,
 } from "@/shared/types";
@@ -87,23 +86,6 @@ describe("StorageChangePortMessage", () => {
 
     expect(message.type).toBe("STORAGE_CHANGE");
     expect(message.changes).toHaveLength(2);
-  });
-});
-
-describe("MonitorMessage types", () => {
-  it("includes START_RECORDING", () => {
-    const msg: MonitorMessage = { type: "START_RECORDING" };
-    expect(msg.type).toBe("START_RECORDING");
-  });
-
-  it("includes STOP_RECORDING", () => {
-    const msg: MonitorMessage = { type: "STOP_RECORDING" };
-    expect(msg.type).toBe("STOP_RECORDING");
-  });
-
-  it("includes SET_EXTENSION_FLAG", () => {
-    const msg: MonitorMessage = { type: "SET_EXTENSION_FLAG" };
-    expect(msg.type).toBe("SET_EXTENSION_FLAG");
   });
 });
 


### PR DESCRIPTION
## Summary
- Declare `storage-interceptor.js` as a manifest MAIN world content script (bypasses CSP + ad blockers)
- Simplify monitor.ts — remove dynamic injection/removal
- Fix extension-initiated changes: run in MAIN world with extension flag
- Clean up unused monitor message types

Closes #48

## Test plan
- [x] All existing E2E tests pass (page-originated changes + diff tests)
- [x] New E2E tests for extension-source attribution (save + delete)
- [x] Recording toggle still works (sidepanel-side filtering)
- [x] 64 unit tests pass, 25 E2E tests pass
- [x] Lint, type-check, build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)