### PR TITLE
feat: resizable and collapsible panels

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Storage Inspector",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "View and edit localStorage and sessionStorage with a proper JSON editor",
   "permissions": ["activeTab", "scripting", "sidePanel"],
   "action": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-storage-inspector",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/sidepanel/components/App.module.css
+++ b/src/sidepanel/components/App.module.css
@@ -66,3 +66,14 @@
   justify-content: center;
   color: #999;
 }
+
+.keyListWrapper {
+  overflow: hidden;
+  flex-shrink: 0;
+  transition: width 0.15s ease;
+}
+
+.keyListCollapsed {
+  width: 0 !important;
+  overflow: hidden;
+}

--- a/src/sidepanel/components/App.tsx
+++ b/src/sidepanel/components/App.tsx
@@ -10,6 +10,7 @@ import { KeyList } from "./KeyList";
 import { ValueEditor } from "./ValueEditor";
 import { ImportExport } from "./ImportExport";
 import { ChangeLog } from "./ChangeLog";
+import { ResizeHandle } from "./ResizeHandle";
 
 type LoadState = "idle" | "loading" | "ready" | "error";
 
@@ -26,6 +27,24 @@ export function App() {
   const [changes, setChanges] = useState<StorageChangeEvent[]>([]);
   const [truncatedCount, setTruncatedCount] = useState(0);
   const recordingRef = useRef(true);
+  const [keysPanelWidth, setKeysPanelWidth] = useState(180);
+  const [keysPanelCollapsed, setKeysPanelCollapsed] = useState(false);
+  const savedKeysPanelWidth = useRef(180);
+
+  const handleKeysResize = useCallback((delta: number) => {
+    setKeysPanelWidth((prev) => Math.min(300, Math.max(80, prev + delta)));
+  }, []);
+
+  const handleKeysCollapseToggle = useCallback(() => {
+    setKeysPanelCollapsed((prev) => {
+      if (prev) {
+        setKeysPanelWidth(savedKeysPanelWidth.current);
+      } else {
+        savedKeysPanelWidth.current = keysPanelWidth;
+      }
+      return !prev;
+    });
+  }, [keysPanelWidth]);
 
   const MAX_CHANGES = 100;
 
@@ -188,15 +207,26 @@ export function App() {
         {loadState === "error" && <div className={styles.error}>{errorMessage}</div>}
         {loadState === "ready" && (
           <>
-            <KeyList
-              entries={filteredEntries}
-              selectedKey={selectedKey}
-              onSelectKey={(key) => { setSelectedKey(key); setAddingNew(false); }}
-              onAddNew={() => {
-                setSelectedKey(null);
-                setAddingNew(true);
-                setNewKeyName("");
-              }}
+            <div
+              className={`${styles.keyListWrapper} ${keysPanelCollapsed ? styles.keyListCollapsed : ""}`}
+              style={keysPanelCollapsed ? undefined : { width: keysPanelWidth }}
+            >
+              <KeyList
+                entries={filteredEntries}
+                selectedKey={selectedKey}
+                onSelectKey={(key) => { setSelectedKey(key); setAddingNew(false); }}
+                onAddNew={() => {
+                  setSelectedKey(null);
+                  setAddingNew(true);
+                  setNewKeyName("");
+                }}
+              />
+            </div>
+            <ResizeHandle
+              direction="horizontal"
+              onResize={handleKeysResize}
+              collapsed={keysPanelCollapsed}
+              onToggleCollapse={handleKeysCollapseToggle}
             />
             {selectedEntry ? (
               <ValueEditor

--- a/src/sidepanel/components/App.tsx
+++ b/src/sidepanel/components/App.tsx
@@ -46,6 +46,14 @@ export function App() {
     });
   }, [keysPanelWidth]);
 
+  const [changeLogHeight, setChangeLogHeight] = useState(200);
+
+  const handleChangeLogResize = useCallback((delta: number) => {
+    setChangeLogHeight((prev) =>
+      Math.min(window.innerHeight * 0.6, Math.max(60, prev - delta)),
+    );
+  }, []);
+
   const MAX_CHANGES = 100;
 
   const addChanges = useCallback((newChanges: StorageChangeEvent[]) => {
@@ -276,13 +284,19 @@ export function App() {
       {loadState === "ready" && (
         <ImportExport entries={entries} onImport={handleImport} />
       )}
-      <ChangeLog
-        changes={changes}
-        recording={recording}
-        truncatedCount={truncatedCount}
-        onToggleRecording={handleToggleRecording}
-        onClear={handleClearChanges}
+      <ResizeHandle
+        direction="vertical"
+        onResize={handleChangeLogResize}
       />
+      <div style={{ height: changeLogHeight, flexShrink: 0 }}>
+        <ChangeLog
+          changes={changes}
+          recording={recording}
+          truncatedCount={truncatedCount}
+          onToggleRecording={handleToggleRecording}
+          onClear={handleClearChanges}
+        />
+      </div>
     </div>
   );
 }

--- a/src/sidepanel/components/ChangeLog.module.css
+++ b/src/sidepanel/components/ChangeLog.module.css
@@ -1,9 +1,8 @@
 .container {
-  border-top: 1px solid #e0e0e0;
   display: flex;
   flex-direction: column;
-  max-height: 40vh;
   overflow: hidden;
+  height: 100%;
 }
 
 .toolbar {

--- a/src/sidepanel/components/KeyList.module.css
+++ b/src/sidepanel/components/KeyList.module.css
@@ -1,5 +1,5 @@
 .list {
-  width: 180px;
+  min-width: 0;
   border-right: 1px solid #e0e0e0;
   overflow-y: auto;
 }

--- a/src/sidepanel/components/ResizeHandle.module.css
+++ b/src/sidepanel/components/ResizeHandle.module.css
@@ -1,0 +1,72 @@
+.handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f0f0f0;
+  border: none;
+  position: relative;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.handle:hover {
+  background: #e0e0e0;
+}
+
+.horizontal {
+  width: 6px;
+  cursor: col-resize;
+  flex-direction: column;
+}
+
+.vertical {
+  height: 6px;
+  cursor: row-resize;
+  flex-direction: row;
+}
+
+.grip {
+  color: #999;
+  font-size: 10px;
+  pointer-events: none;
+  line-height: 1;
+}
+
+.handle:hover .grip {
+  color: #666;
+}
+
+.collapseButton {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  background: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  color: #666;
+  padding: 0;
+  z-index: 1;
+}
+
+.collapseButton:hover {
+  background: #f0f0f0;
+  border-color: #999;
+}
+
+.collapsedHandle {
+  width: 20px;
+  cursor: pointer;
+  background: #f8f8f8;
+}
+
+.collapsedHandle:hover {
+  background: #e8e8e8;
+}

--- a/src/sidepanel/components/ResizeHandle.tsx
+++ b/src/sidepanel/components/ResizeHandle.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useRef } from "react";
+import styles from "./ResizeHandle.module.css";
+
+interface ResizeHandleProps {
+  direction: "horizontal" | "vertical";
+  onResize: (delta: number) => void;
+  onResizeEnd?: () => void;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}
+
+export function ResizeHandle({
+  direction,
+  onResize,
+  onResizeEnd,
+  collapsed,
+  onToggleCollapse,
+}: ResizeHandleProps) {
+  const startPos = useRef(0);
+  const dragging = useRef(false);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (collapsed) return;
+      e.preventDefault();
+      dragging.current = true;
+      startPos.current = direction === "horizontal" ? e.clientX : e.clientY;
+
+      const cursorStyle = direction === "horizontal" ? "col-resize" : "row-resize";
+      document.body.style.cursor = cursorStyle;
+      document.body.style.userSelect = "none";
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if (!dragging.current) return;
+        const currentPos =
+          direction === "horizontal" ? moveEvent.clientX : moveEvent.clientY;
+        const delta = currentPos - startPos.current;
+        startPos.current = currentPos;
+        onResize(delta);
+      };
+
+      const handleMouseUp = () => {
+        dragging.current = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+        onResizeEnd?.();
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [direction, onResize, onResizeEnd, collapsed],
+  );
+
+  if (collapsed) {
+    return (
+      <div
+        className={`${styles.handle} ${styles.horizontal} ${styles.collapsedHandle}`}
+        onClick={onToggleCollapse}
+        data-testid="resize-handle-collapsed"
+      >
+        <span className={styles.grip}>&#9654;</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${styles.handle} ${styles[direction]}`}
+      onMouseDown={handleMouseDown}
+      data-testid={`resize-handle-${direction}`}
+    >
+      {onToggleCollapse && (
+        <button
+          className={styles.collapseButton}
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleCollapse();
+          }}
+          data-testid="collapse-toggle"
+          title="Toggle keys panel"
+        >
+          &#9664;
+        </button>
+      )}
+      <span className={styles.grip}>
+        {direction === "horizontal" ? "\u22EE" : "\u22EF"}
+      </span>
+    </div>
+  );
+}

--- a/tests/e2e/extension.spec.ts
+++ b/tests/e2e/extension.spec.ts
@@ -579,3 +579,45 @@ test.describe("Change Log Diff", () => {
     await sidePanelPage.close();
   });
 });
+
+test.describe("Resizable Panels", () => {
+  test("keys panel collapse toggle hides and shows the key list", async ({
+    page,
+    openSidePanel,
+  }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    // Keys should be visible initially
+    await expect(sidePanelPage.locator("text=basic-test")).toBeVisible();
+
+    // Click collapse toggle
+    await sidePanelPage.getByTestId("collapse-toggle").click();
+
+    // Collapsed handle should be visible
+    await expect(sidePanelPage.getByTestId("resize-handle-collapsed")).toBeVisible();
+
+    // Click to expand
+    await sidePanelPage.getByTestId("resize-handle-collapsed").click();
+
+    // Keys should be visible again
+    await expect(sidePanelPage.locator("text=basic-test")).toBeVisible();
+
+    await sidePanelPage.close();
+  });
+
+  test("horizontal resize handle is visible", async ({ page, openSidePanel }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    await expect(sidePanelPage.getByTestId("resize-handle-horizontal")).toBeVisible();
+
+    await sidePanelPage.close();
+  });
+
+  test("vertical resize handle is visible", async ({ page, openSidePanel }) => {
+    const sidePanelPage = await openSidePanel(page);
+
+    await expect(sidePanelPage.getByTestId("resize-handle-vertical")).toBeVisible();
+
+    await sidePanelPage.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Horizontal resize handle between keys list and value editor (drag to resize 80-300px)
- Vertical resize handle between content and ChangeLog (drag to resize 60px-60vh)
- Keys panel collapse toggle (thin bar with ▶ expand arrow when collapsed)
- Reusable ResizeHandle component with grip dots (⋮ / ⋯)

Closes #52

## Test plan
- [x] E2E tests for collapse toggle, resize handles visible (3 new tests)
- [x] All 28 E2E tests pass, 72 unit tests pass
- [x] Lint, type-check, build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)