### PR TITLE
Show stale-tab banner when panel diverges from active tab

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Storage Inspector",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "View and edit localStorage and sessionStorage with a proper JSON editor",
   "permissions": ["activeTab", "scripting", "sidePanel"],
   "optional_host_permissions": ["<all_urls>"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-storage-inspector",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/src/sidepanel/components/App.tsx
+++ b/src/sidepanel/components/App.tsx
@@ -197,6 +197,7 @@ export function App() {
       tabId: number,
       changeInfo: chrome.tabs.OnUpdatedInfo,
     ) => {
+      // onUpdated fires for title, favicon, and status changes too — only URL changes affect storage.
       if (!changeInfo.url) return;
       if (loadedTabId !== tabId) return;
       void (async () => {

--- a/src/sidepanel/components/App.tsx
+++ b/src/sidepanel/components/App.tsx
@@ -20,6 +20,7 @@ import { ImportExport } from "./ImportExport";
 import { ChangeLog } from "./ChangeLog";
 import { ResizeHandle } from "./ResizeHandle";
 import { OriginIndicator, type OriginState } from "./OriginIndicator";
+import { StaleTabBanner } from "./StaleTabBanner";
 
 type LoadState = "idle" | "loading" | "ready" | "error";
 
@@ -36,6 +37,9 @@ export function App() {
   const [changes, setChanges] = useState<StorageChangeEvent[]>([]);
   const [truncatedCount, setTruncatedCount] = useState(0);
   const [originState, setOriginState] = useState<OriginState>({ kind: "loading" });
+  const [loadedTabId, setLoadedTabId] = useState<number | null>(null);
+  const [activeTabId, setActiveTabId] = useState<number | null>(null);
+  const [bannerDismissedForTabId, setBannerDismissedForTabId] = useState<number | null>(null);
 
   const refreshOriginState = useCallback(async () => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -158,6 +162,8 @@ export function App() {
       const tabEntries = results[0]?.result ?? [];
       setEntries(tabEntries);
       setLoadState("ready");
+      setLoadedTabId(tabId);
+      setBannerDismissedForTabId(null);
       void refreshOriginState();
     } catch (e) {
       setErrorMessage(e instanceof Error ? e.message : "Failed to load storage");
@@ -178,30 +184,29 @@ export function App() {
   }, [refreshOriginState]);
 
   useEffect(() => {
+    const handleActivated = (info: chrome.tabs.OnActivatedInfo) => {
+      setActiveTabId(info.tabId);
+    };
+    chrome.tabs.onActivated.addListener(handleActivated);
+    void getActiveTabId().then((id) => { if (id != null) setActiveTabId(id); });
+    return () => chrome.tabs.onActivated.removeListener(handleActivated);
+  }, []);
+
+  useEffect(() => {
     const handleTabUpdated = (
       tabId: number,
       changeInfo: chrome.tabs.OnUpdatedInfo,
     ) => {
-      // Only URL changes matter here. `onUpdated` also fires for title,
-      // favicon, and loading-status changes — those don't affect the
-      // origin or the storage contents, so filtering on changeInfo.url
-      // avoids spamming reads.
       if (!changeInfo.url) return;
+      if (loadedTabId !== tabId) return;
       void (async () => {
-        const [activeTab] = await chrome.tabs.query({
-          active: true,
-          currentWindow: true,
-        });
-        // Ignore navigations in background tabs — the panel only renders
-        // the active tab's storage.
-        if (activeTab?.id !== tabId) return;
         await refreshOriginState();
         await loadEntries(storageType);
       })();
     };
     chrome.tabs.onUpdated.addListener(handleTabUpdated);
     return () => chrome.tabs.onUpdated.removeListener(handleTabUpdated);
-  }, [refreshOriginState, loadEntries, storageType]);
+  }, [refreshOriginState, loadEntries, storageType, loadedTabId]);
 
   const handleStorageTypeChange = useCallback(
     (type: StorageType) => {
@@ -312,6 +317,12 @@ export function App() {
     ? entries.find((e) => e.key === selectedKey) ?? null
     : null;
 
+  const showStaleTabBanner =
+    loadedTabId != null &&
+    activeTabId != null &&
+    activeTabId !== loadedTabId &&
+    activeTabId !== bannerDismissedForTabId;
+
   // Load on first render
   if (loadState === "idle") {
     loadEntries(storageType);
@@ -323,6 +334,14 @@ export function App() {
         <StorageToggle storageType={storageType} onChange={handleStorageTypeChange} />
         <SearchBar query={searchQuery} onChange={setSearchQuery} />
       </div>
+      {showStaleTabBanner && (
+        <div className={styles.originRow}>
+          <StaleTabBanner
+            onInspect={() => loadEntries(storageType)}
+            onDismiss={() => setBannerDismissedForTabId(activeTabId)}
+          />
+        </div>
+      )}
       <div className={styles.originRow}>
         <OriginIndicator
           state={originState}

--- a/src/sidepanel/components/StaleTabBanner.module.css
+++ b/src/sidepanel/components/StaleTabBanner.module.css
@@ -1,0 +1,56 @@
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  color: #6b5900;
+  background: #fef9e7;
+  border: 1px solid #f0d860;
+  border-radius: 4px;
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+
+.icon {
+  flex-shrink: 0;
+}
+
+.message {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspectButton {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid #c9a800;
+  border-radius: 3px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+  color: #6b5900;
+}
+
+.inspectButton:hover {
+  background: #fdf0b2;
+  border-color: #a68c00;
+}
+
+.closeButton {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  padding: 0 4px;
+  font-size: 14px;
+  cursor: pointer;
+  color: #6b5900;
+  line-height: 1;
+}
+
+.closeButton:hover {
+  color: #3d3300;
+}

--- a/src/sidepanel/components/StaleTabBanner.tsx
+++ b/src/sidepanel/components/StaleTabBanner.tsx
@@ -15,7 +15,7 @@ export function StaleTabBanner({ onInspect, onDismiss }: Props) {
       <button type="button" className={styles.inspectButton} onClick={onInspect}>
         Inspect this tab
       </button>
-      <button type="button" className={styles.closeButton} onClick={onDismiss}>
+      <button type="button" className={styles.closeButton} onClick={onDismiss} aria-label="Dismiss">
         &times;
       </button>
     </div>

--- a/src/sidepanel/components/StaleTabBanner.tsx
+++ b/src/sidepanel/components/StaleTabBanner.tsx
@@ -1,0 +1,23 @@
+import styles from "./StaleTabBanner.module.css";
+
+interface Props {
+  onInspect: () => void;
+  onDismiss: () => void;
+}
+
+const WARNING = "\u26A0";
+
+export function StaleTabBanner({ onInspect, onDismiss }: Props) {
+  return (
+    <div className={styles.banner}>
+      <span className={styles.icon}>{WARNING}</span>
+      <span className={styles.message}>You've switched tabs</span>
+      <button type="button" className={styles.inspectButton} onClick={onInspect}>
+        Inspect this tab
+      </button>
+      <button type="button" className={styles.closeButton} onClick={onDismiss}>
+        &times;
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #58

## Summary

- Add `StaleTabBanner` component with amber/yellow warning styling that appears when the active Chrome tab differs from the tab the panel loaded data from
- Track `loadedTabId` and `activeTabId` via `chrome.tabs.onActivated` listener (no new permissions needed)
- Tighten `onUpdated` handler to only auto-reload for the panel's loaded tab, preventing background-tab navigations from silently swapping panel contents

## Test plan

- [ ] Open panel on foo.com, switch to bar.gov — banner appears, foo.com data and edits preserved
- [ ] Click "Inspect this tab" — panel reloads with bar.gov storage, banner disappears
- [ ] Click dismiss (×) — banner hides, reappears on next tab switch
- [ ] Switch back to original tab — banner gone (active tab matches loaded tab)
- [ ] Navigate within the loaded tab (same-tab URL change) — existing auto-reload still works
- [ ] Switch to a `chrome://` tab and click inspect — lands in existing "unsupported" error state

🤖 Generated with [Claude Code](https://claude.com/claude-code)